### PR TITLE
corrección de botón de iniciar sesión

### DIFF
--- a/RaduiUjedApp/VerProg.cs
+++ b/RaduiUjedApp/VerProg.cs
@@ -336,9 +336,10 @@ namespace RaduiUjedApp
 
         private void button1_Click_1(object sender, EventArgs e)
         {
-            var form1 = new Form1();
-            form1.Show();
-            this.Close();
+            var loginForm = new Form1();
+            loginForm.FormClosed += (s, args) => this.Close(); 
+            loginForm.Show();
+            this.Hide(); 
         }
 
         private async Task CargarCategorias()


### PR DESCRIPTION
Cuando se ingresaba en modo invitado para ver las cartas de programación y querías iniciar sesión la aplicación se cerraba al dar click en el botón de inicio de sesión 
![image](https://github.com/user-attachments/assets/d349ec84-4a94-4e42-8196-0e363a67fdde)
